### PR TITLE
Draft: feat: remove static key restriction in preparation for #48

### DIFF
--- a/src/main/kotlin/org/heigit/ohsome/now/statsservice/stats/AccessRestrictedUserController.kt
+++ b/src/main/kotlin/org/heigit/ohsome/now/statsservice/stats/AccessRestrictedUserController.kt
@@ -50,17 +50,10 @@ class AccessRestrictedUserController {
         @RequestParam(name = "enddate", required = false)
         endDate: Instant?,
 
-        @RequestHeader(value = "Authorization", required = false)
-        authorization: String?,
-
         @TopicsConfig
         @RequestParam("topics", required = true)
         topics: List<@ValidTopic String>
     ): OhsomeFormat<UserResult> {
-        if (authorization == null || authorization != "Basic ${appProperties.token}") {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid Token")
-        }
-
         val result = measure {
             statsService.getStatsByUserId(userId, hashtag, topics, startDate, endDate)
         }


### PR DESCRIPTION
DO NOT MERGE

this removes the current key restriction for the user data endpoint.

Merge only after service is deployed behind API gateway.